### PR TITLE
Fix edit command

### DIFF
--- a/lib/ftl/client.rb
+++ b/lib/ftl/client.rb
@@ -37,9 +37,11 @@ module Ftl
 
     def initialize(args=nil, opts={})
       load_config(opts)
-      @con = Fog::Compute.new(:provider => 'AWS', :aws_secret_access_key => options['SECRET_ACCESS_KEY'], :aws_access_key_id => options['ACCESS_KEY_ID'])
       if args && args.length > 0
         arg = args.reverse.pop
+        if (arg != 'edit')
+          @con = Fog::Compute.new(:provider => 'AWS', :aws_secret_access_key => options['SECRET_ACCESS_KEY'], :aws_access_key_id => options['ACCESS_KEY_ID'])
+        end
         send(arg, args - [arg])
       else
         Ftl.help

--- a/lib/ftl/client.rb
+++ b/lib/ftl/client.rb
@@ -56,14 +56,16 @@ module Ftl
       display "Spinning up FTL..."
       opts = options
       opts = options[:templates][args.first.to_sym] if !options[:templates][args.first.to_sym].nil?
-      server = con.servers.create(:user_data         => opts[:user_data],
-                                  :key_name          => opts[:keypair], 
-                                  :groups            => opts[:groups], 
-                                  :image_id          => opts[:ami], 
-                                  :availability_zone => opts[:availability_zone], 
-                                  :flavor_id         => opts[:instance_type], 
-                                  :username          => opts[:username],
-                                  :tags              => opts[:tags].merge(:Name => args.first)
+      server = con.servers.create(:user_data          => opts[:user_data],
+                                  :key_name           => opts[:keypair], 
+                                  :groups             => opts[:groups], 
+                                  :image_id           => opts[:ami], 
+                                  :availability_zone  => opts[:availability_zone], 
+                                  :flavor_id          => opts[:instance_type], 
+                                  :username           => opts[:username],
+                                  :tags               => opts[:tags].merge(:Name => args.first),
+                                  :subnet_id          => opts[:subnet_id],
+                                  :private_ip_address => opts[:ip_private],
                                   )
       display server
       eval(options[:post_script]) if options[:post_script]


### PR DESCRIPTION
Ftl::Client fails in initialize if ftl.yml doesn’t contain valid AWS access key or secret key. If you try to run “ftl edit” to add these keys, initialize still fails. I’ve added a condition to bypass Fog initialization when the command is “edit”.
